### PR TITLE
#9 fix: corrigido privilégios de acesso dos usuários

### DIFF
--- a/src/components/Equipament-Tables/index.tsx
+++ b/src/components/Equipament-Tables/index.tsx
@@ -13,6 +13,13 @@ import {
   StyledTableRow
 } from './style'
 import { EditButton } from './../edit-button/index'
+import { useContext } from 'react'
+import { AuthContext } from '../../contexts/auth'
+interface AuthContextType {
+  user: {
+    role: string
+  }
+}
 
 export interface equipament {
   tippingNumber: string
@@ -64,6 +71,8 @@ interface propType {
 }
 
 export default function EquipamentsTables({ equipaments }: propType) {
+  const { user } = useContext(AuthContext) as AuthContextType
+  const role = user?.role
   return (
     <TableContainer
       sx={{
@@ -97,8 +106,12 @@ export default function EquipamentsTables({ equipaments }: propType) {
             <StyledTableCell align="center">Potência</StyledTableCell>
             <StyledTableCell align="center" />
             <StyledTableCell align="center" />
-            <StyledTableCell align="center" />
-            <StyledTableCell align="center" />
+              <StyledTableCell align="center" />
+            <>
+            {(role === 'administrador' || role === 'gerente') && ( // Ajusta espaço da tabela do Administrador e Gerente
+              <StyledTableCell align="center" />
+            )}
+            </>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -151,9 +164,13 @@ export default function EquipamentsTables({ equipaments }: propType) {
                 <StyledTableCell align="center">
                   {equipaments.power}
                 </StyledTableCell>
+                <>
+                {(role === 'administrador' || role === 'gerente') && ( // Os perfis de administrador e de gerente irão ter acesso ao botão de edição do equipamento
                 <StyledTableCell align="center">
                   <EditButton disabled />
                 </StyledTableCell>
+                )}
+                </>
                 <StyledTableCell align="center">
                   <Button disabled>
                     <DeleteIcon />

--- a/src/components/edit-button/index.tsx
+++ b/src/components/edit-button/index.tsx
@@ -1,14 +1,28 @@
 import { ButtonProps } from '@mui/material'
 import EditIcon from '@mui/icons-material/Edit'
 import { Props, StyledEditButton } from './styles'
+import { useContext } from 'react'
+import { AuthContext } from '../../contexts/auth'
+
+interface AuthContextType {
+  user: {
+    role: string
+  }
+}
 
 export type StyledButton = ButtonProps & Props
 
 export const EditButton = (props: StyledButton) => {
+  const { user } = useContext(AuthContext) as AuthContextType
+  const role = user?.role
   return (
-    <StyledEditButton {...props} data-testid="button">
-      <EditIcon />
-      {props.children}
-    </StyledEditButton>
+    <>
+      {role === 'administrador' && (
+        <StyledEditButton {...props} data-testid="button">
+         <EditIcon />
+         {props.children}
+        </StyledEditButton>
+      )} 
+    </> 
   )
 }

--- a/src/pages/ScreenEquipaments/index.tsx
+++ b/src/pages/ScreenEquipaments/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import {
   Container,
   FindContainer,
@@ -32,6 +32,12 @@ import { toast } from 'react-toastify'
 import api from '../../api/config'
 import { AxiosResponse } from 'axios'
 import { useNavigate } from 'react-router-dom'
+import { AuthContext } from '../../contexts/auth'
+interface AuthContextType {
+  user: {
+    role: string
+  }
+}
 
 export interface SearchParams {
   tippingNumber: string
@@ -126,6 +132,8 @@ export default function ScreenEquipaments() {
   const [equipaments, setEquipaments] = useState<equipament[]>([])
   const [basicSearch, setbasicSearch] = useState<string>('')
   const navigate = useNavigate()
+  const { user } = useContext(AuthContext) as AuthContextType
+  const role = user?.role
   const initialValues = {
     tippingNumber: '',
 
@@ -265,7 +273,6 @@ export default function ScreenEquipaments() {
             onChange={handleChange}
             onKeyPress={(ev) => {
               if (ev.key === 'Enter') {
-                // Do code here
                 if (basicSearch === '') {
                   getEquipaments()
                 } else {
@@ -292,9 +299,11 @@ export default function ScreenEquipaments() {
             Filtros
             <FilterListOutlinedIcon sx={{ ml: '70px', color: '#A1A5BC' }} />
           </ButtonFilters>
-          <ButtonCad onClick={() => navigate('/equipment-register')}>
-            Cadastrar Equipamento
-          </ButtonCad>
+          {role !== 'consulta' && ( // Apenas o perfil de consulta não tem acesso ao botao de cadastro de equipamento
+            <ButtonCad onClick={() => navigate('/equipment-register')}>
+              Cadastrar Equipamento
+            </ButtonCad>
+          )}
         </Box>
       </FindContainer>
       {renderEquipmentTable()}
@@ -372,11 +381,6 @@ export default function ScreenEquipaments() {
                     value="TECHNICAL_RESERVE"
                     sx={{ justifyContent: 'center' }}>
                     Reserva Técnica
-                  </MenuItem>
-                  <MenuItem
-                    value="DOWNGRADED"
-                    sx={{ justifyContent: 'center' }}>
-                    Baixado
                   </MenuItem>
                 </StyledSelect>
               </Box>

--- a/src/pages/order-services/index.tsx
+++ b/src/pages/order-services/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable eqeqeq */
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Typography } from '@mui/material'
 import FilterListIcon from '@mui/icons-material/FilterList'
@@ -11,7 +11,12 @@ import api from '../../api/config'
 import { AxiosResponse } from 'axios'
 import { toast } from 'react-toastify'
 import FilterOrderService from '../../components/filter-order-service'
-
+import { AuthContext } from '../../contexts/auth'
+interface AuthContextType {
+  user: {
+    role: string
+  }
+}
 interface OrderService {
   id: string
   date: string
@@ -43,6 +48,8 @@ export const OrderServices = () => {
   const [tippingNumber, setTippingNumber] = useState('')
   const [filters, setFilters] = useState<filterType>({})
   const [openFilter, setOpenFilter] = useState(false)
+  const { user } = useContext(AuthContext) as AuthContextType
+  const role = user?.role
 
   const handleApplyFilter = (values: any) => {
     toast.success('Filtro aplicado')
@@ -123,15 +130,17 @@ export const OrderServices = () => {
                 Limpar Filtros
               </Button>
             )}
-            <Button
-              width="240px"
-              height="62px"
-              textColor="#FFFFFF"
-              styledColor="#16878C"
-              onClick={() => navigate('/create-order-service')}
-              borderRadius="10px">
-              Cadastrar OS
-            </Button>
+            {role !== 'consulta' && ( // Apenas o perfil de consulta não tem acesso ao botão de cadastro de equipamento
+              <Button
+                width="240px"
+                height="62px"
+                textColor="#FFFFFF"
+                styledColor="#16878C"
+                onClick={() => navigate('/create-order-service')}
+                borderRadius="10px">
+                Cadastrar OS
+              </Button>
+            )}
           </ButtonGroup>
         </StyledCard>
         <OderServiceTable orderServices={orderServices} />


### PR DESCRIPTION
## Modificações
Foi ajustado as permissões de usuários quanto a alguns assuntos, como cadastro de OS e equipamentos, assim como edição e exclusão
( Os que estão na segunda linha, é como estava antes das mudanças )
- [x] Usuário Administrador criado e com as devidas permissões
- Botão excluir e editar devem aparecer
- [x] Usuário Gerente criado e com as devidas permissões
- Aparece o botão de excluir - OS e Equip.
- [x] Usuário Básico criado e com as devidas permissões
- Aparece o botão de editar e excluir - OS e Equip.
- [x] Usuário Consulta criado e com as devidas permissões
-  Atualmente consegue realizar cadastro e aparece o botão de editar e excluir - OS e Equip.


## Descrição
Foram feitas alterações no cadastro, para que apenas certos tipos de perfis consigam ter acesso a certas funcionalidades, como no caso de cadastro de equipamentos, onde apenas o perfil consulta não pode ter acesso ao cadastro de equipamentos e OS.

## _Issue_ relacionado

[#9](https://github.com/fga-eps-mds/2022-2-Alectrion-DOC/issues/9) US 03: Visualizar perfil de usuário

## Como foi testado?
Foram sendo feitas mudanças e já de imediato, sendo testadas em todos os tipos de usuário, para ver se as permissões se aplicavam

## Criterios de aceitação
- [x] Precisa haver os 4 tipos de usuários (Administrador, Gerente, Básico, Consulta);
- [x] Somente usuários administradores podem visualizar informações de outros usuários;
