### PR TITLE
Adiciona build no workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,4 @@
-name: SonarCloud
+name: CodeAnalysis
 on:
   pull_request:
     branches:
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 0 
       - name: Install dependencies
         run: yarn
+      - name: Build
+        run: yarn build
       - name: Test and coverage
         run: yarn test:all
       - name: SonarCloud Scan
@@ -24,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GIT_TOKEN}}
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
   get_metrics:
-    if: github.event.pull_request.merged == true
+    if: always() && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: sonarcloud
     steps:


### PR DESCRIPTION
## Modificações
Muda o nome da action para ficar mais intuitivo.
Adiciona o build para o ci, assim evitando aprovar PR que não conseguem fazer o build.
Faz o get_metrics toda vez que o PR for feito o merge
