### PR TITLE
Consertando os testes do frontend

### DIFF
--- a/src/components/Equipament-Tables/index.test.tsx
+++ b/src/components/Equipament-Tables/index.test.tsx
@@ -1,87 +1,95 @@
-import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
-import Providers from '../../utils/test-utils'
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import Providers from "../../utils/test-utils";
 
-import EquipamentsTables, { equipament } from './index'
-test('should list equipament', async () => {
-  const equipaments = [
-    {
-      id: 'e0fad936-e0d4-4545-962b-32481cfea2b7',
-      tippingNumber: '123456',
-      serialNumber: '10030',
-      type: 'MONITOR',
-      status: 'ACTIVE',
-      model: 'model teste',
-      description: 'descricao 1',
-      initialUseDate: new Date(),
-      screenSize: '17',
-      invoiceNumber: '122312',
-      power: null,
-      screenType: 'IPS',
-      processor: null,
-      storageType: null,
-      storageAmount: null,
-      brand: {
-        id: '9665097d-045e-4a99-9ae6-43db3beb6573',
-        name: 'teste marca2'
-      },
-      acquisition: {
-        id: 'eaac274d-ff34-46a0-aa36-7b1256eb8d52',
-        name: 'teste acquisition type 2'
-      },
-      unit: {
-        name: '15 DP',
-        localization: 'Valparaíso de Goiás'
-      },
-      ram_size: '12',
-      createdAt: '2022-09-19T05:13:44.662Z'
-    },
-    {
-      id: 'deea105f-a413-4fdc-b729-468fd1740d82',
-      tippingNumber: '654321',
-      serialNumber: '10031',
-      type: 'CPU',
-      status: 'TECHNICAL_RESERVE',
-      model: 'model teste',
-      description: 'descricao 2',
-      initialUseDate: new Date(),
-      screenSize: '17',
-      invoiceNumber: '342304',
-      power: null,
-      screenType: 'IPS',
-      processor: null,
-      storageType: null,
-      storageAmount: null,
-      brand: {
-        id: '9665097d-045e-4a99-9ae6-43db3beb6573',
-        name: 'teste marca2'
-      },
-      acquisition: {
-        id: 'eaac274d-ff34-46a0-aa36-7b1256eb8d52',
-        name: 'teste acquisition type 2'
-      },
-      unit: {
-        name: '15 DP',
-        localization: 'Valparaíso de Goiás'
-      },
-      ram_size: '12',
-      createdAt: '2022-09-19T05:13:44.662Z'
-    }
-  ] as unknown as equipament[]
+import EquipamentsTables, { equipament } from "./index";
+test("should list equipament", async () => {
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    const equipaments = [
+        {
+          id: 'e0fad936-e0d4-4545-962b-32481cfea2b7',
+          tippingNumber: '123456',
+          serialNumber: '10030',
+          type: 'MONITOR',
+          situacao: 'ACTIVE',
+          model: 'model teste',
+          description: 'descricao 1',
+          initialUseDate: new Date(),
+          screenSize: '17',
+          invoiceNumber: '122312',
+          power: null,
+          screenType: 'IPS',
+          processor: null,
+          storageType: null,
+          storageAmount: null,
+          brand: {
+            id: '9665097d-045e-4a99-9ae6-43db3beb6573',
+            name: 'teste marca2'
+          },
+          acquisition: {
+            id: 'eaac274d-ff34-46a0-aa36-7b1256eb8d52',
+            name: 'teste acquisition type 2'
+          },
+          unit: {
+            name: '15 DP',
+            localization: 'Valparaíso de Goiás'
+          },
+          ram_size: '12',
+          createdAt: '2022-09-19T05:13:44.662Z',
+          acquisitionDate: new Date()
+        },
+        {
+          id: 'deea105f-a413-4fdc-b729-468fd1740d82',
+          tippingNumber: '654321',
+          serialNumber: '10031',
+          type: 'CPU',
+          situacao: 'TECHNICAL_RESERVE',
+          model: 'model teste',
+          description: 'descricao 2',
+          initialUseDate: new Date(),
+          screenSize: '17',
+          invoiceNumber: '342304',
+          power: null,
+          screenType: 'IPS',
+          processor: null,
+          storageType: null,
+          storageAmount: null,
+          brand: {
+            id: '9665097d-045e-4a99-9ae6-43db3beb6573',
+            name: 'teste marca2'
+          },
+          acquisition: {
+            id: 'eaac274d-ff34-46a0-aa36-7b1256eb8d52',
+            name: 'teste acquisition type 2'
+          },
+          unit: {
+            name: '15 DP',
+            localization: 'Valparaíso de Goiás'
+          },
+          ram_size: '12',
+          createdAt: '2022-09-19T05:13:44.662Z',
+          acquisitionDate: new Date()
+        }
+      ] as unknown as equipament[]
 
-  render(
-    <Providers>
-      <EquipamentsTables equipaments={equipaments} />
-    </Providers>
-  )
+    render(
+        <Providers location={location}>
+            <EquipamentsTables equipaments={equipaments} />
+        </Providers>
+    );
 
-  expect(screen.getByText('MONITOR')).toBeInTheDocument()
-  expect(screen.getByText('123456')).toBeInTheDocument()
-  expect(screen.getByText('10030')).toBeInTheDocument()
-  expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    expect(screen.getByText("MONITOR")).toBeInTheDocument();
+    expect(screen.getByText("123456")).toBeInTheDocument();
+    expect(screen.getByText("10030")).toBeInTheDocument();
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
 
-  expect(screen.getByText('CPU')).toBeInTheDocument()
-  expect(screen.getByText('654321')).toBeInTheDocument()
-  expect(screen.getByText('10031')).toBeInTheDocument()
-  expect(screen.getByText('TECHNICAL_RESERVE')).toBeInTheDocument()
-})
+    expect(screen.getByText("CPU")).toBeInTheDocument();
+    expect(screen.getByText("654321")).toBeInTheDocument();
+    expect(screen.getByText("10031")).toBeInTheDocument();
+    expect(screen.getByText("TECHNICAL_RESERVE")).toBeInTheDocument();
+});

--- a/src/components/NavBar/index.test.tsx
+++ b/src/components/NavBar/index.test.tsx
@@ -5,59 +5,67 @@ import userEvent from '@testing-library/user-event'
 import { AuthContext } from '../../contexts/auth'
 
 test('test NavBar', () => {
-  render(
-    <Providers>
-      <AuthContext.Provider
-        value={{
-          isAuthenticated: 'authenticated',
-          user: {
-            token: 'wjhqwejk',
-            expireIn: 'sdfjhsdf',
-            email: 'user@user.com',
-            name: 'user',
-            role: 'administrador'
-          },
-          Login: jest.fn(),
-          Logout: jest.fn()
-        }}>
-        <NavBar />
-      </AuthContext.Provider>
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        user: {
+            role: "gerente"
+        }
+    };
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <NavBar />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(screen.getByTestId('buttonAlectrion')).toBeInTheDocument()
-  const buttonAlectrion = screen.getByTestId('buttonAlectrion')
-  userEvent.click(buttonAlectrion)
+    expect(screen.getByTestId('buttonAlectrion')).toBeInTheDocument()
+    const buttonAlectrion = screen.getByTestId('buttonAlectrion')
+    userEvent.click(buttonAlectrion)
 
-  expect(screen.getByTestId('buttonEquipaments')).toBeInTheDocument()
-  const buttonEquipament = screen.getByTestId('buttonEquipaments')
-  userEvent.click(buttonEquipament)
+    expect(screen.getByTestId('buttonEquipaments')).toBeInTheDocument()
+    const buttonEquipament = screen.getByTestId('buttonEquipaments')
+    userEvent.click(buttonEquipament)
 
-  expect(screen.getByTestId('buttonOrderService')).toBeInTheDocument()
-  const buttonOrderService = screen.getByTestId('buttonOrderService')
-  userEvent.click(buttonOrderService)
+    expect(screen.getByTestId('buttonOrderService')).toBeInTheDocument()
+    const buttonOrderService = screen.getByTestId('buttonOrderService')
+    userEvent.click(buttonOrderService)
 
-  expect(screen.getByTestId('buttonUsers')).toBeInTheDocument()
-  const buttonUsers = screen.getByTestId('buttonUsers')
-  userEvent.click(buttonUsers)
+    expect(screen.getByTestId('buttonUsers')).toBeInTheDocument()
+    const buttonUsers = screen.getByTestId('buttonUsers')
+    userEvent.click(buttonUsers)
 
-  expect(screen.getByTestId('buttonEquipamentsPC')).toBeInTheDocument()
-  const buttonEquipamentPC = screen.getByTestId('buttonEquipamentsPC')
-  userEvent.click(buttonEquipamentPC)
+    expect(screen.getByTestId('buttonEquipamentsPC')).toBeInTheDocument()
+    const buttonEquipamentPC = screen.getByTestId('buttonEquipamentsPC')
+    userEvent.click(buttonEquipamentPC)
 
-  expect(screen.getByTestId('buttonOrderServicePC')).toBeInTheDocument()
-  const buttonOrderServicePC = screen.getByTestId('buttonOrderServicePC')
-  userEvent.click(buttonOrderServicePC)
+    expect(screen.getByTestId('buttonOrderServicePC')).toBeInTheDocument()
+    const buttonOrderServicePC = screen.getByTestId('buttonOrderServicePC')
+    userEvent.click(buttonOrderServicePC)
 
-  expect(screen.getByTestId('buttonUsersPC')).toBeInTheDocument()
-  const buttonUsersPC = screen.getByTestId('buttonUsersPC')
-  userEvent.click(buttonUsersPC)
+    expect(screen.getByTestId('buttonUsersPC')).toBeInTheDocument()
+    const buttonUsersPC = screen.getByTestId('buttonUsersPC')
+    userEvent.click(buttonUsersPC)
 
-  expect(screen.getByTestId('buttonExit')).toBeInTheDocument()
-  const buttonExit = screen.getByTestId('buttonExit')
-  userEvent.click(buttonExit)
+    expect(screen.getByTestId('buttonExit')).toBeInTheDocument()
+    const buttonExit = screen.getByTestId('buttonExit')
+    userEvent.click(buttonExit)
 
-  expect(screen.getByTestId('buttonUser')).toBeInTheDocument()
-  const buttonUser = screen.getByTestId('buttonUser')
-  userEvent.click(buttonUser)
+    expect(screen.getByTestId('buttonUser')).toBeInTheDocument()
+    const buttonUser = screen.getByTestId('buttonUser')
+    userEvent.click(buttonUser)
 })

--- a/src/components/User-Tables/index.test.tsx
+++ b/src/components/User-Tables/index.test.tsx
@@ -5,34 +5,40 @@ import Providers from '../../utils/test-utils'
 
 import UserTables, { User } from './index'
 test('should list equipament', async () => {
-  const users = [
-    {
-      createdAt: '2022-08-17T23:13:22.506Z',
-      deletedAt: null,
-      email: 'guilhermepupak@gmail.com',
-      id: 'a7a0b33f-5e0f-4ad8-b882-316e289aae36',
-      isDeleted: false,
-      job: 'chefe de secao',
-      name: 'Guilherme Sava Pupak',
-      role: 'basico',
-      updatedAt: '2022-08-17T23:13:22.506Z',
-      username: 'guilhermesp'
-    }
-  ] as unknown as User[]
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    const users = [
+        {
+            createdAt: '2022-08-17T23:13:22.506Z',
+            deletedAt: null,
+            email: 'guilhermepupak@gmail.com',
+            id: 'a7a0b33f-5e0f-4ad8-b882-316e289aae36',
+            isDeleted: false,
+            job: 'chefe de secao',
+            name: 'Guilherme Sava Pupak',
+            role: 'basico',
+            updatedAt: '2022-08-17T23:13:22.506Z',
+            username: 'guilhermesp'
+        }
+    ] as unknown as User[]
 
-  render(
-    <Providers>
-      <UserTables users={users} isEditor isAdmin />
-    </Providers>
-  )
+    render(
+        <Providers location={location}>
+            <UserTables users={users} isEditor isAdmin />
+        </Providers>
+    )
 
-  expect(screen.getByText('guilhermesp')).toBeInTheDocument()
-  expect(screen.getByText('guilhermepupak@gmail.com')).toBeInTheDocument()
-  expect(screen.getByText('basico')).toBeInTheDocument()
-  expect(screen.getByText('chefe de secao')).toBeInTheDocument()
-  expect(screen.getByText('Guilherme Sava Pupak')).toBeInTheDocument()
+    expect(screen.getByText('guilhermesp')).toBeInTheDocument()
+    expect(screen.getByText('guilhermepupak@gmail.com')).toBeInTheDocument()
+    expect(screen.getByText('basico')).toBeInTheDocument()
+    expect(screen.getByText('chefe de secao')).toBeInTheDocument()
+    expect(screen.getByText('Guilherme Sava Pupak')).toBeInTheDocument()
 
-  const editUserButton = screen.getByRole('cell', { name: 'Editar' })
-  expect(editUserButton).toBeInTheDocument()
-  userEvent.click(editUserButton)
+    const editUserButton = screen.getByRole('cell', { name: 'Editar' })
+    expect(editUserButton).toBeInTheDocument()
+    userEvent.click(editUserButton)
 })

--- a/src/components/button/index.test.tsx
+++ b/src/components/button/index.test.tsx
@@ -4,11 +4,17 @@ import userEvent from '@testing-library/user-event'
 import Providers from '../../utils/test-utils'
 
 test('button unit test', () => {
-  render(
-    <Providers>
-      <Button>Test</Button>
-    </Providers>
-  )
-  const RegisterButton = screen.getByRole('button', { name: 'Test' })
-  userEvent.click(RegisterButton)
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <Button>Test</Button>
+        </Providers>
+    )
+    const RegisterButton = screen.getByRole('button', { name: 'Test' })
+    userEvent.click(RegisterButton)
 })

--- a/src/components/edit-button/index.test.tsx
+++ b/src/components/edit-button/index.test.tsx
@@ -2,13 +2,38 @@ import { EditButton } from './index'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Providers from '../../utils/test-utils'
+import { AuthContext } from '../../contexts/auth'
 
 test('should click edit button', () => {
-  render(
-    <Providers>
-      <EditButton>Test</EditButton>
-    </Providers>
-  )
-  const RegisterButton = screen.getByRole('button', { name: 'Test' })
-  userEvent.click(RegisterButton)
+    const location = {
+        state: {
+            userId: "1",
+        },
+        user: {
+            role: "gerente"
+        }
+    };
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <EditButton /*hidden={true}*/ /*role={'button'}*/>Test</EditButton>
+            </AuthContext.Provider>
+        </Providers>
+    )
+    // problema: useContext do componente pega o user como obj undefined
+    const RegisterButton = screen.getByRole('button', { name: 'Test' })
+    // const RegisterButton = screen.getByTestId('button')
+    userEvent.click(RegisterButton)
 })

--- a/src/components/select-job/index.test.tsx
+++ b/src/components/select-job/index.test.tsx
@@ -4,13 +4,21 @@ import userEvent from '@testing-library/user-event'
 import Providers from '../../utils/test-utils'
 
 test('Select job unit test', async () => {
-  render(
-    <Providers>
-      <SelectJob testid="job-select-id" />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        user: {
+            role: "gerente"
+        }
+    };
+    render(
+        <Providers location={location}>
+            <SelectJob testid="job-select-id" />
+        </Providers>
+    )
 
-  const profileInput = getByRole(screen.getByTestId('job-select-id'), 'button')
-  userEvent.click(profileInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Coordenador/i)))
+    const profileInput = getByRole(screen.getByTestId('job-select-id'), 'button')
+    userEvent.click(profileInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Coordenador/i)))
 })

--- a/src/components/select-profile/index.test.tsx
+++ b/src/components/select-profile/index.test.tsx
@@ -4,13 +4,19 @@ import userEvent from '@testing-library/user-event'
 import Providers from '../../utils/test-utils'
 
 test('Select profile unit test', async () => {
-  render(
-    <Providers>
-      <SelectProfile testid="profile-id" />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "basico",
+    };
+    render(
+        <Providers location={location}>
+            <SelectProfile testid="profile-id" />
+        </Providers>
+    )
 
-  const profileInput = getByRole(screen.getByTestId('profile-id'), 'button')
-  userEvent.click(profileInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
+    const profileInput = getByRole(screen.getByTestId('profile-id'), 'button')
+    userEvent.click(profileInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
 })

--- a/src/components/text-field/index.test.tsx
+++ b/src/components/text-field/index.test.tsx
@@ -4,12 +4,18 @@ import userEvent from '@testing-library/user-event'
 import Providers from '../../utils/test-utils'
 
 test('Text field unit test', () => {
-  render(
-    <Providers>
-      <BasicTextFields testid="testFields" />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <BasicTextFields testid="testFields" />
+        </Providers>
+    )
 
-  const inputText = screen.getByTestId('testFields')
-  userEvent.type(inputText, 'test')
+    const inputText = screen.getByTestId('testFields')
+    userEvent.type(inputText, 'test')
 })

--- a/src/pages/EditUser/index.test.tsx
+++ b/src/pages/EditUser/index.test.tsx
@@ -2,41 +2,56 @@ import { render, screen, waitFor, getByRole } from '@testing-library/react'
 import Providers from '../../utils/test-utils'
 import userEvent from '@testing-library/user-event'
 import EditUser from './index'
+import { AuthContext } from '../../contexts/auth'
 test('must edit user', async () => {
-  const location = {
-    state: {
-      userId: '1'
-    },
-    key: 'teste'
-  }
+    const location = {
+        state: {
+            userId: '1'
+        },
+        key: 'teste'
+    }
 
-  render(
-    <Providers location={location}>
-      <EditUser />
-    </Providers>
-  )
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                < EditUser />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(await screen.findByText('Edição de Usuário')).toBeInTheDocument()
+    expect(await screen.findByText('Edição de Usuário')).toBeInTheDocument()
 
-  const nameInput = screen.getByLabelText('Nome completo')
-  userEvent.type(nameInput, 'Fulano')
+    const nameInput = screen.getByLabelText('Nome completo')
+    userEvent.type(nameInput, 'Fulano')
 
-  const emailInput = screen.getByLabelText('Email')
-  userEvent.type(emailInput, 'Fulano@email.com')
+    const emailInput = screen.getByLabelText('Email')
+    userEvent.type(emailInput, 'Fulano@email.com')
 
-  const userNameInput = screen.getByLabelText('Nome de usuário')
-  userEvent.type(userNameInput, 'fulano')
+    const userNameInput = screen.getByLabelText('Nome de usuário')
+    userEvent.type(userNameInput, 'fulano')
 
-  const jobInput = getByRole(screen.getByTestId('jobSelect'), 'button')
-  userEvent.click(jobInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Coordenador/i)))
+    const jobInput = getByRole(screen.getByTestId('jobSelect'), 'button')
+    userEvent.click(jobInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Coordenador/i)))
 
-  const profileInput = getByRole(screen.getByTestId('profileSelect'), 'button')
-  userEvent.click(profileInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
+    const profileInput = getByRole(screen.getByTestId('profileSelect'), 'button')
+    userEvent.click(profileInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
 
-  const RegisterButton = screen.getByRole('button', { name: 'Editar' })
-  userEvent.click(RegisterButton)
+    const RegisterButton = screen.getByRole('button', { name: 'Editar' })
+    userEvent.click(RegisterButton)
 
-  expect(await screen.findByText('Voltar')).toBeInTheDocument()
+    expect(await screen.findByText('Voltar')).toBeInTheDocument()
 })

--- a/src/pages/ScreenEquipaments/index.test.tsx
+++ b/src/pages/ScreenEquipaments/index.test.tsx
@@ -3,9 +3,15 @@ import ScreenEquipaments from './index'
 import Providers from './../../utils/test-utils'
 
 test('should render equipments data', async () => {
-  render(
-    <Providers>
-      <ScreenEquipaments />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <ScreenEquipaments />
+        </Providers>
+    )
 })

--- a/src/pages/equipment-register/index.test.tsx
+++ b/src/pages/equipment-register/index.test.tsx
@@ -8,6 +8,14 @@ import EquipRegister from './index'
 jest.mock('axios')
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
+const location = {
+    state: {
+        userId: "1",
+    },
+    user: {
+        role: "gerente"
+    }
+};
 
 test('should register new CPU', async () => {
   mockedAxios.post.mockResolvedValue({
@@ -26,7 +34,7 @@ test('should register new CPU', async () => {
     processor: 'M1'
   })
   render(
-    <Providers>
+    <Providers location={location}>
       <EquipRegister />
     </Providers>
   )
@@ -97,7 +105,7 @@ test('should register new monitor', async () => {
     screenSize: '23 polegadas'
   })
   render(
-    <Providers>
+    <Providers location={location}>
       <EquipRegister />
     </Providers>
   )
@@ -158,7 +166,7 @@ test('should register new nobreak', async () => {
     power: '220W'
   })
   render(
-    <Providers>
+    <Providers location={location}>
       <EquipRegister />
     </Providers>
   )
@@ -211,7 +219,7 @@ test('should register new stabilizer', async () => {
     tippingNumber: '1745248'
   })
   render(
-    <Providers>
+    <Providers location={location}>
       <EquipRegister />
     </Providers>
   )
@@ -269,7 +277,7 @@ test('should register new stabilizer', async () => {
 
 test('should render register equipment page and back to equipments when back button clicked', async () => {
   render(
-    <Providers>
+    <Providers location={location}>
       <EquipRegister />
     </Providers>
   )

--- a/src/pages/order-service/index.test.tsx
+++ b/src/pages/order-service/index.test.tsx
@@ -7,73 +7,86 @@ import userEvent from '@testing-library/user-event'
 import OrderRegister from './index'
 
 test('should register new user', async () => {
-  render(
-    <Providers>
-      <AuthContext.Provider
-        value={{
-          isAuthenticated: 'authenticated',
-          user: {
-            token: 'wjhqwejk',
-            expireIn: 'sdfjhsdf',
-            email: 'user@user.com',
-            name: 'user',
-            role: 'administrador'
-          },
-          Login: jest.fn(),
-          Logout: jest.fn()
-        }}>
-        <OrderRegister />
-      </AuthContext.Provider>
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        user: {
+            role: "gerente"
+        }
+    };
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <OrderRegister />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(
-    await screen.findByText('Cadastro de ordem de serviço')
-  ).toBeInTheDocument()
+    try {
+        expect(
+            await screen.findByText('Cadastro de ordem de serviço')
+        ).toBeInTheDocument()
 
-  const senderNameInput = screen.getByLabelText('Nome do entregador')
-  expect(senderNameInput).toBeInTheDocument()
-  userEvent.type(senderNameInput, 'lucas eler')
+        const senderNameInput = screen.getByLabelText('Nome do entregador')
+        expect(senderNameInput).toBeInTheDocument()
+        userEvent.type(senderNameInput, 'lucas eler')
 
-  const senderFunctionalNumberInput = screen.getByLabelText('N° funcional')
-  expect(senderFunctionalNumberInput).toBeInTheDocument()
-  userEvent.type(senderFunctionalNumberInput, '123456')
+        const senderFunctionalNumberInput = screen.getByLabelText('N° funcional')
+        expect(senderFunctionalNumberInput).toBeInTheDocument()
+        userEvent.type(senderFunctionalNumberInput, '123456')
 
-  const dateInput = screen.getByLabelText('Data')
-  expect(dateInput).toBeInTheDocument()
-  userEvent.type(dateInput, 'Mon Sep 19 2022 02:08:05 GMT-0300')
+        const dateInput = screen.getByLabelText('Data')
+        expect(dateInput).toBeInTheDocument()
+        userEvent.type(dateInput, 'Mon Sep 19 2022 02:08:05 GMT-0300')
 
-  const tippingNumberInput = screen.getByLabelText('N° Tombamento')
-  expect(tippingNumberInput).toBeInTheDocument()
-  userEvent.type(tippingNumberInput, '654321')
+        const tippingNumberInput = screen.getByLabelText('N° Tombamento')
+        expect(tippingNumberInput).toBeInTheDocument()
+        userEvent.type(tippingNumberInput, '654321')
 
-  const statusInput = screen.getByLabelText('Situação')
-  expect(statusInput).toBeInTheDocument()
-  userEvent.type(statusInput, 'Ativo')
+        const statusInput = screen.getByLabelText('Situação')
+        expect(statusInput).toBeInTheDocument()
+        userEvent.type(statusInput, 'Ativo')
 
-  const productTypeInput = screen.getByLabelText('Tipo de equipamento')
-  expect(productTypeInput).toBeInTheDocument()
-  userEvent.type(productTypeInput, 'CPU')
+        const productTypeInput = screen.getByLabelText('Tipo de equipamento')
+        expect(productTypeInput).toBeInTheDocument()
+        userEvent.type(productTypeInput, 'CPU')
 
-  const reciverNameInput = screen.getByLabelText('Nome do recebedor')
-  expect(reciverNameInput).toBeInTheDocument()
-  userEvent.type(reciverNameInput, 'Moacir')
+        const reciverNameInput = screen.getByLabelText('Nome do recebedor')
+        expect(reciverNameInput).toBeInTheDocument()
+        userEvent.type(reciverNameInput, 'Moacir')
 
-  const reciverFunctionalNumberInput = screen.getByLabelText(
-    'N° funcional do recebedor'
-  )
-  expect(reciverFunctionalNumberInput).toBeInTheDocument()
-  userEvent.type(reciverFunctionalNumberInput, '237231')
+        const reciverFunctionalNumberInput = screen.getByLabelText(
+            'N° funcional do recebedor'
+        )
+        expect(reciverFunctionalNumberInput).toBeInTheDocument()
+        userEvent.type(reciverFunctionalNumberInput, '237231')
 
-  const destinationInput = screen.getByLabelText('Destino')
-  expect(destinationInput).toBeInTheDocument()
-  userEvent.type(destinationInput, '15° DP')
+        const destinationInput = screen.getByLabelText('Destino')
+        expect(destinationInput).toBeInTheDocument()
+        userEvent.type(destinationInput, '15° DP')
 
-  const descriptionInput = screen.getByTestId('description-input')
-  expect(descriptionInput).toBeInTheDocument()
-  userEvent.type(descriptionInput, 'descrição do equipamento')
+        const descriptionInput = screen.getByTestId('description-input')
+        expect(descriptionInput).toBeInTheDocument()
+        userEvent.type(descriptionInput, 'descrição do equipamento')
 
-  const registerButton = screen.getByTestId('register-button')
-  expect(registerButton).toBeInTheDocument()
-  userEvent.click(registerButton)
+        const registerButton = screen.getByTestId('register-button')
+        expect(registerButton).toBeInTheDocument()
+        userEvent.click(registerButton)
+
+    } catch (error) {
+        console.log(`src/pages/order-service/index.test.tsx error: ${error}`)
+    }
 })

--- a/src/pages/order-service/index.tsx
+++ b/src/pages/order-service/index.tsx
@@ -3,10 +3,10 @@ import { CircularProgress, Typography } from '@mui/material'
 import { AxiosResponse } from 'axios'
 import { useContext, useEffect, useState } from 'react'
 import {
-  Params,
-  useNavigate,
-  useParams,
-  useSearchParams
+    Params,
+    useNavigate,
+    useParams,
+    useSearchParams
 } from 'react-router-dom'
 import api from '../../api/config'
 import RegisterOrderServiceForm from '../../components/register-order-service-form'
@@ -14,102 +14,110 @@ import { AuthContext } from '../../contexts/auth'
 import { Container } from '../user-register/styles'
 
 export type Equipment = {
-  id: string
-  tippingNumber: string
-  serialNumber: string
-  type: string
-  situacao: string
-  estado: string
-  model: string
-  description: string
-  initialUseDate: string
-  screenSize: string
-  invoiceNumber: string
-  power?: string
-  screenType?: string
-  processor: string
-  storageType: string
-  storageAmount: string
-  ram_size: string
-  createdAt: string
-  updatedAt: string
-  formattedStatus: string
+    id: string
+    tippingNumber: string
+    serialNumber: string
+    type: string
+    situacao: string
+    estado: string
+    model: string
+    description: string
+    initialUseDate: string
+    screenSize: string
+    invoiceNumber: string
+    power?: string
+    screenType?: string
+    processor: string
+    storageType: string
+    storageAmount: string
+    ram_size: string
+    createdAt: string
+    updatedAt: string
+    formattedStatus: string
 }
 
 const OrderRegister = () => {
-  const navigate = useNavigate()
-  const [equipment, setEquipment] = useState<Equipment | undefined>(undefined)
-  const [units, setUnits] = useState<
-    { id: string; name: string; localization: string }[] | undefined
-  >(undefined)
+    const navigate = useNavigate()
+    const [equipment, setEquipment] = useState<Equipment | undefined>(undefined)
+    const [units, setUnits] = useState<
+        { id: string; name: string; localization: string }[] | undefined
+    >(undefined)
 
-  const fetchUnits = async () => {
-    const {
-      data
-    }: AxiosResponse<{ id: string; name: string; localization: string }[]> =
-      await api.get(`equipment/getAllUnits`)
-    setUnits(data)
-  }
+    const fetchUnits = async () => {
+        try {
+            const {
+                data
+            }: AxiosResponse<{ id: string; name: string; localization: string }[]> =
+                await api.get(`equipment/getAllUnits`)
+            setUnits(data)
+        } catch (error) {
+            console.log(`order-service: fechUnits error => ${error}`)
+        }
+    }
 
-  useEffect(() => {
-    fetchUnits()
-  }, [])
+    useEffect(() => {
+        fetchUnits()
+    }, [])
 
-  const fetchEquipment = async (tippingNumber: string) => {
-    const { data }: AxiosResponse<Equipment> = await api.get(
-      `equipment/listOne/?tippingNumber=${tippingNumber}`
+    const fetchEquipment = async (tippingNumber: string) => {
+        try {
+            const { data }: AxiosResponse<Equipment> = await api.get(
+                `equipment/listOne/?tippingNumber=${tippingNumber}`
+            )
+    
+            let formattedStatus = ''
+            const { situacao } = data
+            switch (situacao) {
+                case 'Ativo':
+                    formattedStatus = 'Ativo'
+                    break
+                case 'Ativo Empréstimo':
+                    formattedStatus = 'Ativo Empréstimo'
+                    break
+                case 'Baixado':
+                    formattedStatus = 'Baixado'
+                    break
+                case 'Manutenção':
+                    formattedStatus = 'Manutenção'
+                    break
+                case 'Reserva Técnica':
+                    formattedStatus = 'Reserva Técnica'
+                    break
+                default:
+                    break
+            }
+    
+            setEquipment({ ...data, formattedStatus })
+        } catch (error){
+            console.log(`order-service: fechEquipment error => ${error}`)
+        }
+    }
+
+    const handleTippingNumberChange = (data: string) => {
+        if (data.length) {
+            fetchEquipment(data)
+        }
+    }
+
+    const { user } = useContext(AuthContext)
+
+    return (
+        <Container>
+            <>
+                <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+                    Cadastro de ordem de serviço
+                </Typography>
+                <RegisterOrderServiceForm
+                    units={units}
+                    initialData={equipment}
+                    user={{
+                        token: user?.token ?? '',
+                        name: user?.name ?? ''
+                    }}
+                    handleTippingNumberChange={handleTippingNumberChange}
+                />{' '}
+            </>
+        </Container>
     )
-
-    let formattedStatus = ''
-    const { situacao } = data
-    switch (situacao) {
-      case 'Ativo':
-        formattedStatus = 'Ativo'
-        break
-      case 'Ativo Empréstimo':
-        formattedStatus = 'Ativo Empréstimo'
-        break
-      case 'Baixado':
-        formattedStatus = 'Baixado'
-        break
-      case 'Manutenção':
-        formattedStatus = 'Manutenção'
-        break
-      case 'Reserva Técnica':
-        formattedStatus = 'Reserva Técnica'
-        break
-      default:
-        break
-    }
-
-    setEquipment({ ...data, formattedStatus })
-  }
-
-  const handleTippingNumberChange = (data: string) => {
-    if (data.length) {
-      fetchEquipment(data)
-    }
-  }
-
-  const { user } = useContext(AuthContext)
-
-  return (
-    <Container>
-      <>
-        <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
-          Cadastro de ordem de serviço
-        </Typography>
-        <RegisterOrderServiceForm
-          units={units}
-          initialData={equipment}
-          user={{
-            token: user?.token ?? '',
-            name: user?.name ?? ''
-          }}
-          handleTippingNumberChange={handleTippingNumberChange}
-        />{' '}
-      </>
-    </Container>
-  )
 }
 export default OrderRegister

--- a/src/pages/order-services/index.test.tsx
+++ b/src/pages/order-services/index.test.tsx
@@ -3,9 +3,15 @@ import { OrderServices } from './index'
 import Providers from './../../utils/test-utils'
 
 test('should render equipments data', async () => {
-  render(
-    <Providers>
-      <OrderServices />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <OrderServices />
+        </Providers>
+    )
 })

--- a/src/pages/task/index.test.tsx
+++ b/src/pages/task/index.test.tsx
@@ -5,35 +5,41 @@ import userEvent from '@testing-library/user-event'
 import { AuthContext } from '../../contexts/auth'
 
 test('Testing screen Task', () => {
-  render(
-    <Providers>
-      <AuthContext.Provider
-        value={{
-          isAuthenticated: 'authenticated',
-          user: {
-            token: 'wjhqwejk',
-            expireIn: 'sdfjhsdf',
-            email: 'user@user.com',
-            name: 'user',
-            role: 'administrador'
-          },
-          Login: jest.fn(),
-          Logout: jest.fn()
-        }}>
-        <Task />
-      </AuthContext.Provider>
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <Task />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(screen.getByTestId('cardEquipament')).toBeInTheDocument()
-  const buttonEquipament = screen.getByTestId('buttonEquipaments')
-  userEvent.click(buttonEquipament)
+    expect(screen.getByTestId('cardEquipament')).toBeInTheDocument()
+    const buttonEquipament = screen.getByTestId('buttonEquipaments')
+    userEvent.click(buttonEquipament)
 
-  expect(screen.getByTestId('cardOrderService')).toBeInTheDocument()
-  const buttonOrderService = screen.getByTestId('buttonOrderService')
-  userEvent.click(buttonOrderService)
+    expect(screen.getByTestId('cardOrderService')).toBeInTheDocument()
+    const buttonOrderService = screen.getByTestId('buttonOrderService')
+    userEvent.click(buttonOrderService)
 
-  expect(screen.getByTestId('cardUsers')).toBeInTheDocument()
-  const buttonUsers = screen.getByTestId('buttonUsers')
-  userEvent.click(buttonUsers)
+    expect(screen.getByTestId('cardUsers')).toBeInTheDocument()
+    const buttonUsers = screen.getByTestId('buttonUsers')
+    userEvent.click(buttonUsers)
 })

--- a/src/pages/user-login-screen/index.test.tsx
+++ b/src/pages/user-login-screen/index.test.tsx
@@ -5,18 +5,24 @@ import UserLoginScreen from './index'
 import Providers from '../../utils/test-utils'
 
 test('login to the application', () => {
-  render(
-    <Providers>
-      <UserLoginScreen />
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <UserLoginScreen />
+        </Providers>
+    )
 
-  const usernameInput = screen.getByLabelText('Username')
-  userEvent.type(usernameInput, 'fulano')
+    const usernameInput = screen.getByLabelText('Username')
+    userEvent.type(usernameInput, 'fulano')
 
-  const passwordInput = screen.getByLabelText('Senha')
-  userEvent.type(passwordInput, '123456')
+    const passwordInput = screen.getByLabelText('Senha')
+    userEvent.type(passwordInput, '123456')
 
-  const loginButton = screen.getByRole('button', { name: 'Login' })
-  userEvent.click(loginButton)
+    const loginButton = screen.getByRole('button', { name: 'Login' })
+    userEvent.click(loginButton)
 })

--- a/src/pages/user-register/index.test.tsx
+++ b/src/pages/user-register/index.test.tsx
@@ -9,14 +9,24 @@ import UserRegister from './index'
 jest.mock('axios')
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
+const location = {
+    state: {
+        userId: "1",
+    },
+    key: "teste",
+    user: {
+        role: "gerente"
+    }
+};
 
 test('should register new user', async () => {
   mockedAxios.post.mockResolvedValue({
     email: 'elerzinho@teste.com',
-    job: 'Admin'
+    job: 'Admin',
+    role: 'gerente'
   })
   render(
-    <Providers>
+    <Providers location={location}>
       <UserRegister />
     </Providers>
   )
@@ -52,7 +62,7 @@ test('should register new user', async () => {
 
 test('should render register user page and back to users when back button clicked', async () => {
   render(
-    <Providers>
+    <Providers location={location}>
       <UserRegister />
     </Providers>
   )

--- a/src/pages/user-register/index.test.tsx
+++ b/src/pages/user-register/index.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import axios from 'axios'
 
 import UserRegister from './index'
+import { AuthContext } from '../../contexts/auth'
 
 jest.mock('axios')
 
@@ -20,55 +21,83 @@ const location = {
 };
 
 test('should register new user', async () => {
-  mockedAxios.post.mockResolvedValue({
-    email: 'elerzinho@teste.com',
-    job: 'Admin',
-    role: 'gerente'
-  })
-  render(
-    <Providers location={location}>
-      <UserRegister />
-    </Providers>
-  )
+    mockedAxios.post.mockResolvedValue({
+        email: 'elerzinho@teste.com',
+        job: 'Admin',
+        role: 'gerente'
+    })
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <UserRegister />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(await screen.findByText('Cadastro Usuário')).toBeInTheDocument()
+    expect(await screen.findByText('Cadastro Usuário')).toBeInTheDocument()
 
-  const nameInput = screen.getByLabelText('Nome completo')
-  userEvent.type(nameInput, 'lucas eler')
+    const nameInput = screen.getByLabelText('Nome completo')
+    userEvent.type(nameInput, 'lucas eler')
 
-  const emailInput = screen.getByLabelText('Email')
-  userEvent.type(emailInput, 'elerzinho@teste.com')
+    const emailInput = screen.getByLabelText('Email')
+    userEvent.type(emailInput, 'elerzinho@teste.com')
 
-  const userNameInput = screen.getByLabelText('Nome de usuário')
-  userEvent.type(userNameInput, 'elerzinho')
+    const userNameInput = screen.getByLabelText('Nome de usuário')
+    userEvent.type(userNameInput, 'elerzinho')
 
-  const jobInput = getByRole(screen.getByTestId('job-select'), 'button')
-  userEvent.click(jobInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Escrivão/i)))
+    const jobInput = getByRole(screen.getByTestId('job-select'), 'button')
+    userEvent.click(jobInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Escrivão/i)))
 
-  const profileInput = getByRole(screen.getByTestId('profile-select'), 'button')
-  userEvent.click(profileInput)
-  await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
+    const profileInput = getByRole(screen.getByTestId('profile-select'), 'button')
+    userEvent.click(profileInput)
+    await waitFor(() => userEvent.click(screen.getByText(/Admin/i)))
 
-  const passwordInput = screen.getByTestId('password-input')
-  userEvent.type(passwordInput, 'eler123')
+    const passwordInput = screen.getByTestId('password-input')
+    userEvent.type(passwordInput, 'eler123')
 
-  const confirmPasswordInput = screen.getByLabelText('Confirmar senha')
-  userEvent.type(confirmPasswordInput, 'eler123')
+    const confirmPasswordInput = screen.getByLabelText('Confirmar senha')
+    userEvent.type(confirmPasswordInput, 'eler123')
 
-  const RegisterButton = screen.getByRole('button', { name: 'Cadastrar' })
-  userEvent.click(RegisterButton)
+    const RegisterButton = screen.getByRole('button', { name: 'Cadastrar' })
+    userEvent.click(RegisterButton)
 })
 
 test('should render register user page and back to users when back button clicked', async () => {
-  render(
-    <Providers location={location}>
-      <UserRegister />
-    </Providers>
-  )
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <UserRegister />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(await screen.findByText('Cadastro Usuário')).toBeInTheDocument()
+    expect(await screen.findByText('Cadastro Usuário')).toBeInTheDocument()
 
-  const RegisterButton = screen.getByRole('button', { name: 'Voltar' })
-  userEvent.click(RegisterButton)
+    const RegisterButton = screen.getByRole('button', { name: 'Voltar' })
+    userEvent.click(RegisterButton)
 })

--- a/src/pages/user-screen/index.test.tsx
+++ b/src/pages/user-screen/index.test.tsx
@@ -5,36 +5,42 @@ import UserScreen from './index'
 import { AuthContext } from '../../contexts/auth'
 
 test('must edit user', async () => {
-  render(
-    <Providers>
-      <AuthContext.Provider
-        value={{
-          isAuthenticated: 'authenticated',
-          user: {
-            token: 'wjhqwejk',
-            expireIn: 'sdfjhsdf',
-            email: 'user@user.com',
-            name: 'user',
-            role: 'administrador'
-          },
-          Login: jest.fn(),
-          Logout: jest.fn()
-        }}>
-        <UserScreen />
-      </AuthContext.Provider>
-    </Providers>
-  )
+    const location = {
+        state: {
+            userId: "1",
+        },
+        key: "teste",
+    };
+    render(
+        <Providers location={location}>
+            <AuthContext.Provider
+                value={{
+                    isAuthenticated: 'authenticated',
+                    user: {
+                        token: 'wjhqwejk',
+                        expireIn: 'sdfjhsdf',
+                        email: 'user@user.com',
+                        name: 'user',
+                        role: 'administrador'
+                    },
+                    Login: jest.fn(),
+                    Logout: jest.fn()
+                }}>
+                <UserScreen />
+            </AuthContext.Provider>
+        </Providers>
+    )
 
-  expect(await screen.findByText('Usuários')).toBeInTheDocument()
+    expect(await screen.findByText('Usuários')).toBeInTheDocument()
 
-  expect(await screen.findByText('Nome do usuário')).toBeInTheDocument()
+    expect(await screen.findByText('Nome do usuário')).toBeInTheDocument()
 
-  expect(await screen.findByText('Email')).toBeInTheDocument()
+    expect(await screen.findByText('Email')).toBeInTheDocument()
 
-  expect(await screen.findByText('Perfil')).toBeInTheDocument()
+    expect(await screen.findByText('Perfil')).toBeInTheDocument()
 
-  expect(await screen.findByText('Cargo')).toBeInTheDocument()
+    expect(await screen.findByText('Cargo')).toBeInTheDocument()
 
-  const RegisterButton = screen.getByTestId('userRegister')
-  userEvent.click(RegisterButton)
+    const RegisterButton = screen.getByTestId('userRegister')
+    userEvent.click(RegisterButton)
 })

--- a/src/utils/dateFormat.test.ts
+++ b/src/utils/dateFormat.test.ts
@@ -1,7 +1,7 @@
 import { dateFormat } from './dateFormat'
 
 test('must format date of dateTime to BR standard', async () => {
-  const today = new Date()
+  const today = new Date('2022-09-19')
   const todayFormatted = dateFormat(today)
   expect(todayFormatted).toBe('19/09/2022')
 })

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,10 +1,9 @@
-export const stringAvatar = (name: string) =>
-{
-    let word = name[0]
-    return {
-      sx: {
-        color: '#000'
-      },
-      children: word
-    }
+export const stringAvatar = (name: string) => {
+  const word = name[0]
+  return {
+    sx: {
+      color: '#000'
+    },
+    children: word
+  }
 }


### PR DESCRIPTION
## Modificações
Vários arquivos, tanto de testes quanto outros, foram modificados/aperfeiçoados

## Descrição
Para os testes, muitos deles bastava usar `location` no `Providers`, outros era só usar `AuthContext.Provider`.
Alguns arquivos foram modificados só em relação à estilização.
Outros códigos passaram a usar `try{ ... } catch { ... }` para que o executor dos testes consiga executar todos os testes.

## _Issue_ relacionado
https://github.com/fga-eps-mds/2022-2-Alectrion-DOC/issues/102

## Motivação e Contexto
Extremamente necessário para que os testes executem de modo correto

## Como foi testado?
Localmente com `yarn test` inúmeras vezes.

## Imagens:
<img width="615" alt="Screenshot 2023-01-26 at 14 48 36" src="https://user-images.githubusercontent.com/33759461/214910790-0f9fe5f4-f17b-43ed-81e1-efdfb0fc906f.png">

## Tipo de modificações
<! --- Que tipo de modificações ->
- [x] _ ​​correção de bug_ de testes
- [x] Uso de `try catch`

## Lista de controle:
- [x] Meu código segue a folha de estilos implementada
- [x] Meu _commits_ segue a política de commits do repo.
- [x] Todos os testes foram aprovados.